### PR TITLE
fix the repository link

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "author": "Paul Jackson (http://jaaco.uk/)",
   "repository": {
     "type": "git",
-    "url": "git@github.com:paulja/memory-streams-js.git"
+    "url": "git@github.com:thirdiron/memory-streams-js.git"
   },
-  "homepage": "https://github.com/paulja/memory-streams-js",
+  "homepage": "https://github.com/thirdiron/memory-streams-js",
   "main": "index.js",
   "typings": "index.d.ts",
   "directories": {


### PR DESCRIPTION
Hi there!  It looks like this package was moved to this repo before 0.1.3 was released.  This PR updates package.json so that at least the next release will have a link to the proper repo.  I've also filed https://github.com/paulja/memory-streams-js/pull/20 to mark the old repo as unmaintained.

All of this will help anyone finding this package to find its source and determine whether or not it is malicious.